### PR TITLE
Added :preserve_order option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -67,6 +67,7 @@ A String which contains any non-UTF8 character will be regarded as "binary" and 
     :printable_with_syck  => true,
     :escape_b_specific    => true,
     :escape_as_utf8       => true
+    :preserve_order       => true
   )
 
   # or simply set this for a safe roundtrip with Syck.
@@ -97,6 +98,10 @@ A String which contains any non-UTF8 character will be regarded as "binary" and 
 - :escape_as_utf8
   - default: false
   - When set to true, Ya2YAML uses Ruby-like escape sequences in UTF8 code instead of "\uXXXX" style in UCS code. It also suppresses use of "\L" and "\P" (escape sequences for LS and PS).
+
+- :preserve_order
+  - default: false
+  - When set to true, the order of keys in hashes will be the natural hash order rather than sorted alphabetically or explicitelly (usefull for syck/psych roundtrip and ruby >= 1.9.2)
 
 - :syck_compatible
   - default: false

--- a/lib/ya2yaml.rb
+++ b/lib/ya2yaml.rb
@@ -54,6 +54,8 @@ class Ya2YAML
               o = (x_order <=> y_order)
               (o != 0) ? o : (x.to_s <=> y.to_s)
             }
+          elsif @options[:preserve_order]
+            hash_keys = obj.keys
           else
             hash_keys = obj.keys.sort {|x, y| x.to_s <=> y.to_s }
           end

--- a/test/test.rb
+++ b/test/test.rb
@@ -137,6 +137,21 @@ class TC_Ya2YAML < Test::Unit::TestCase
     }
   end
 
+  def test_preserve_order
+    h = {}
+    h['a'] = 1
+    h['c'] = 3
+    h['b'] = 2
+    y = h.ya2yaml(
+      :preserve_order => true
+    )
+    assert_equal(
+      "--- \na: 1\nc: 3\nb: 2\n",
+      y,
+      'the natural hash order should be preserved'
+    )
+  end if RUBY_VERSION >= "1.9"
+
   def test_normalize_line_breaks
     [
       ["\n\n\n\n",           "--- \"\\n\\n\\n\\n\"\n"],


### PR DESCRIPTION
In ya2yaml the order of hashes as always being sorted alphabetically. With rails 1.9.2 the natural keys order is the order in which the keys have been added to the hash. This comes handy when doing roundtrip with sych/psyck to preserve the order for example in locale files.
