### PR TITLE
Adding an option to dump symbols in a more natural format

### DIFF
--- a/lib/ya2yaml.rb
+++ b/lib/ya2yaml.rb
@@ -63,7 +63,7 @@ class Ya2YAML
             key = emit(k, level + 1)
             if (
               is_one_plain_line?(key) ||
-              key =~ /\A(#{REX_BOOL}|#{REX_FLOAT}|#{REX_INT}|#{REX_NULL})\z/x
+              key =~ /\A(#{REX_BOOL}|#{REX_FLOAT}|#{REX_INT}|#{REX_NULL}|#{REX_SYMBOL})\z/x
             )
               indent + key + ': ' + emit(obj[k], level + 1)
             else
@@ -92,7 +92,8 @@ class Ya2YAML
         u_sec = (obj.usec != 0) ? sprintf(".%.6d", obj.usec) : ''
         obj.strftime("%Y-%m-%d %H:%M:%S#{u_sec} #{off_hm}")
       when Symbol
-        '!ruby/symbol ' + emit_string(obj.to_s, level)
+        prefix = @options[:use_natural_symbols] && is_one_plain_line?(obj.to_s) ? ":" : "!ruby/symbol "
+        prefix + emit_string(obj.to_s, level)
       when Range
         '!ruby/range ' + obj.to_s
       when Regexp
@@ -359,6 +360,9 @@ class Ya2YAML
     /x
     REX_VALUE = /
       =
+    /x
+    REX_SYMBOL = /
+      \A:.*
     /x
   end
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -358,6 +358,17 @@ class TC_Ya2YAML < Test::Unit::TestCase
 #		assert_equal(symbol3, result_symbol3)
   end
 
+  def test_roundtrip_natural_symbols
+    symbol1 = :"Batman: The Dark Knight - Why So Serious?!"
+    result_symbol1 = YAML.load(symbol1.ya2yaml(:use_natural_symbols => true))
+    assert_equal(symbol1, result_symbol1)
+
+    symbol2 = :batman
+    assert(symbol2.ya2yaml(:use_natural_symbols => true).include?(":batman"))
+    result_symbol2 = YAML.load(symbol2.ya2yaml(:use_natural_symbols => true))
+    assert_equal(symbol2, result_symbol2)
+  end
+
   def test_roundtrip_types
     objects = [
       [],


### PR DESCRIPTION
The current ya2yaml dump of a Ruby symbol looks like this:

`:batman.ya2yaml`

```
--- !ruby/symbol batman
```

While this works, it's a little hard on the eyes.  Symbols as hash keys are even worse:

`{ :batman => "dark knight" }.ya2yaml`

```
--- 
? !ruby/symbol batman
: "dark knight"
```

The Ruby YAML parser knows how to deal with symbols natively using the colon syntax, so why not output them that way?  This pull request adds an option to `#ya2yaml` called `:use_natural_symbols` that emits symbols prefixed by the more familiar colon:

`:batman.ya2yaml(:use_natural_symbols => true)`

```
--- :batman
```

`{ :batman => "dark knight" }.ya2yaml(:use_natural_symbols => true)`

```
--- 
:batman: "dark night"
```
