### PR TITLE
Ruby 2.4

### DIFF
--- a/lib/ya2yaml.rb
+++ b/lib/ya2yaml.rb
@@ -78,7 +78,7 @@ class Ya2YAML
         emit_string(obj, level)
       when TrueClass, FalseClass
         obj.to_s
-      when Fixnum, Bignum, Float
+      when Integer, Float
         obj.to_s
       when Date
         obj.to_s

--- a/ya2yaml.gemspec
+++ b/ya2yaml.gemspec
@@ -2,12 +2,12 @@
 
 Gem::Specification.new do |s|
   s.name = %q{ya2yaml}
-  s.version = "0.31"
+  s.version = "0.32"
 
   s.required_rubygems_version = nil if s.respond_to? :required_rubygems_version=
   s.authors = ["Akira FUNAI"]
   s.cert_chain = nil
-  s.date = %q{2012-02-20}
+  s.date = %q{2017-06-13}
   s.email = %q{akira@funai.com}
   s.extra_rdoc_files = ["README.rdoc"]
   s.files = ["lib/ya2yaml.rb", "README.rdoc", "LICENSE", "test/t.gif", "test/t.yaml", "test/test.rb"]


### PR DESCRIPTION
Warning is removed. Older version will also work.